### PR TITLE
[codex] fix(ci): update pinned GitHub Actions for 1.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: vp run test:cover
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: coverage
           path: coverage/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - uses: voidzero-dev/setup-vp@9446e853b27985e00fb1b21193be026fc09198db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@9446e853b27985e00fb1b21193be026fc09198db
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa
         with:
           node-version: '24'
           cache: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,13 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7c1e4cf0b20d7c1872b26569c00ba908797a59bf
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7c1e4cf0b20d7c1872b26569c00ba908797a59bf
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba
         with:
           category: '/language:${{matrix.language}}'
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Setup CodeQL
         id: setup-codeql
-        uses: github/codeql-action/setup-codeql@7c1e4cf0b20d7c1872b26569c00ba908797a59bf
+        uses: github/codeql-action/setup-codeql@9e0d7b8d25671d64c341c19c0152d693099fb5ba
 
       - name: Run custom CodeQL query tests
         run: ${{ steps.setup-codeql.outputs.codeql-path }} test run --additional-packs codeql/queries/javascript codeql/tests --threads=0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
@@ -49,7 +49,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          rm -rf dist/release
           mkdir -p dist/release
           cp dist/vite/main.js dist/release/main.js
           cp dist/vite/styles.css dist/release/styles.css
@@ -73,16 +74,6 @@ jobs:
           test -s dist/release/styles.css
           test -s dist/release/manifest.json
 
-      - name: Generate SBOM
-        run: vp run sbom:release
-
-      - name: Generate checksums
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd dist/release
-          sha256sum main.js manifest.json styles.css sbom.cdx.json > SHA256SUMS
-
       - name: Attest release artifacts
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
@@ -90,8 +81,6 @@ jobs:
             dist/release/main.js
             dist/release/manifest.json
             dist/release/styles.css
-            dist/release/SHA256SUMS
-          sbom-path: dist/release/sbom.cdx.json
 
       - name: Upload release bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -115,8 +104,6 @@ jobs:
           - main.js
           - manifest.json
           - styles.css
-          - SHA256SUMS
-          - sbom.cdx.json
 
           Verify provenance with:
           gh attestation verify main.js -R ${GITHUB_REPOSITORY}
@@ -126,8 +113,6 @@ jobs:
               dist/release/main.js \
               dist/release/manifest.json \
               dist/release/styles.css \
-              dist/release/SHA256SUMS \
-              dist/release/sbom.cdx.json \
               --clobber
             gh release edit "${GITHUB_REF_NAME}" \
               --title "Vaultman ${GITHUB_REF_NAME}" \
@@ -137,8 +122,6 @@ jobs:
               dist/release/main.js \
               dist/release/manifest.json \
               dist/release/styles.css \
-              dist/release/SHA256SUMS \
-              dist/release/sbom.cdx.json \
               --verify-tag \
               --title "Vaultman ${GITHUB_REF_NAME}" \
               --notes-file "${notes_file}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           fi
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@9446e853b27985e00fb1b21193be026fc09198db
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa
         with:
           node-version: '24'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           sbom-path: dist/release/sbom.cdx.json
 
       - name: Upload release bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: vaultman-release-${{ github.run_id }}
           path: dist/release/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Checkout immutable ref
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           sha256sum main.js manifest.json styles.css sbom.cdx.json > SHA256SUMS
 
       - name: Attest release artifacts
-        uses: actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-path: |
             dist/release/main.js

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - name: Run OpenSSF Scorecard

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,6 +28,6 @@ jobs:
           results_format: sarif
           publish_results: false
       - name: Upload Scorecard SARIF
-        uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Summary

Prepares the 1.1.1 patch release by integrating the green Dependabot workflow-action update PRs into a single release branch.

Changes are limited to pinned GitHub Actions SHAs and release workflow packaging in:

- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/release.yml`
- `.github/workflows/scorecard.yml`

The final marker commit includes `Release-As: 1.1.1` so release-please can cut the patch release instead of ignoring the `chore(deps)` commits.

## Included Dependabot PRs

- #10 `actions/attest`
- #11 `voidzero-dev/setup-vp`
- #12 `actions/checkout`
- #13 `github/codeql-action`
- #14 `actions/upload-artifact`

## Obsidian release packaging

The release workflow now publishes only the files supported by Obsidian plugin releases:

- `main.js`
- `manifest.json`
- `styles.css`

`sbom.cdx.json` and `SHA256SUMS` are no longer generated into `dist/release` or uploaded as GitHub Release assets. Artifact attestations still cover the three supported plugin files.

## Validation

- `pnpm run security:audit` passed before the packaging follow-up. Prod audit has no high+ advisories; dev audit still reports the existing moderate `brace-expansion` advisory for 1.1.2 follow-up.
- `pnpm run verify` passed before the packaging follow-up: lint/check/build, unit 145 files / 932 tests, component 104 files / 500 tests.
- Workflow YAML parse passed for all `.github/workflows/*.yml` after the packaging follow-up.
- `rg` confirmed `.github/workflows/release.yml` no longer references `SHA256SUMS` or `sbom.cdx.json`.
- `git diff --check` passed after the packaging follow-up.

## Notes

This branch contains no AI workflow files and does not touch product source code.